### PR TITLE
change logic to retrieve messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.0.4] - 2025-10-04
+
+- Change the logic to receive the income messages.
+
+- Remove redundancy in the client code that uses “XMLHttpRequest” lib.
+
+- Change end-point “/retrieveMessages” to get the parameter through the JWT value.
+
+
 ## [1.0.3] - 2025-01-01
 
 - Add button to log off.

--- a/src/main/java/com/mendonca/menssagerchat/controller/MessageContoller.java
+++ b/src/main/java/com/mendonca/menssagerchat/controller/MessageContoller.java
@@ -66,8 +66,11 @@ public class MessageContoller {
 	
 	
 	@CrossOrigin(origins = "*")
-	@GetMapping("/retrieveMessages/{userName}")
-	public List<PayloadMessage> retrieveMessages(@PathVariable String userName){
+	@GetMapping("/retrieveMessages")
+	public synchronized List<PayloadMessage> retrieveMessages(){
+		
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();		
+		String userName = authentication.getName();
 		
 		validateUserAuthenticate(userName);
 		
@@ -75,15 +78,21 @@ public class MessageContoller {
 			
 	}
 	
-	
 	private void validateUserAuthenticate(String userName){
 		if(!ChatMendoncaBean.menssagesManager.containsKey(userName)) {  
 			throw new ChatException("User not Authenticate");
 		}
-		
-		
 	}
 	
+	@CrossOrigin(origins = "*")
+	@GetMapping("/retrieveStatusOperation")
+	public ResponseEntity<Integer> operationStatus(){
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();		
+		String userName = authentication.getName();
+		validateUserAuthenticate(userName);
+		int statusOperation= ChatMendoncaBean.menssagesManager.get(userName).assistStatus();
+		return ResponseEntity.status(HttpStatus.OK).body(statusOperation);
+	}
 	
 	
 }

--- a/src/main/resources/static/javascript/workers.js
+++ b/src/main/resources/static/javascript/workers.js
@@ -1,5 +1,5 @@
 
-const baseUrl = 'https://192.168.1.239:8443/';
+const baseUrl = 'https://192.168.0.225:8443/';
 var menssage;
 
 setInterval(function() {
@@ -16,12 +16,16 @@ setInterval(function() {
     var userJwt = parameters['jwt'];
     
     var xhttp = new XMLHttpRequest();
-	var finalURl = baseUrl + 'message/retrieveMessages/'+userName;
+	
+	var finalURl = baseUrl + 'message/retrieveStatusOperation';
 
 	xhttp.onreadystatechange = function() {
-		if (this.readyState == 4 && this.status == 200) {			
-			menssage = xhttp.responseText;
-            postMessage(menssage);
+		
+		if (this.readyState == 4 && this.status == 200 ) {			
+			statusReturned = xhttp.responseText;
+			console.log('get status ->> '+statusReturned);
+
+            postMessage(statusReturned);
               
 		}else{
 			postMessage(this.status);


### PR DESCRIPTION
-Change the logic to receive the income messages.
-Remove redundancy in the client code that uses “XMLHttpRequest” lib.
-Change end-point “/retrieveMessages” to get the parameter through the JWT value.

Observation - The goal of this change is to keep the source code simpler and also change the current logic to retrieve messages in order to accommodate futures features in this project.
